### PR TITLE
test: run doctests

### DIFF
--- a/.github/workflows/on-push-pr.yaml
+++ b/.github/workflows/on-push-pr.yaml
@@ -43,6 +43,7 @@ jobs:
           rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --all-targets --verbose
+      - run: cargo test --doc
 
   clippy_packages:
     runs-on: ubuntu-latest

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! It exposes the trait [`TokenRetriever`] which exposes a single method [`retrieve`](TokenRetriever::retrieve) which will retrieve a token with
 //! an expiration time:
 //!
-//! ```rust
+//! ```ignore
 //! pub trait TokenRetriever {
 //!     fn retrieve(&self) -> Result<Token, TokenRetrieverError>;
 //! }
@@ -14,7 +14,7 @@
 //!
 //! Token:
 //!
-//! ```rust
+//! ```ignore
 //! pub struct Token {
 //!     expires_at: DateTime<Utc>,
 //!     access_token: AccessToken,


### PR DESCRIPTION
The pipelines for testing the project were calling `cargo test --all-targets --verbose` which excludes doctests. This PR adds an additional line to run any existing doc tests and fixed some of the documented Rust code so it doesn't run since it wouldn't compile on its own.