### PR TITLE
chore: remove ureq dev-dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,15 +445,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,16 +664,6 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
-
-[[package]]
-name = "flate2"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1497,7 +1478,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ureq",
  "url",
  "uuid",
  "vaultrs",
@@ -2064,7 +2044,6 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2727,22 +2706,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ authors = ["The New Relic Agent Control Team"]
 publish = false
 license-file = "./LICENSE.md"
 
-[lints.rust]
-missing_docs = "warn"
 
 [dependencies]
 chrono = "0.4"
@@ -26,7 +24,6 @@ assert_matches = "1.5.0"
 httpmock = "0.7.0"
 mockall = "0.13.1"
 mockall_double = "0.3.1"
-ureq = "2"
 url = "2"
 http = "1"
 thiserror = "2"

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -30,76 +30,17 @@ pub trait HttpClient {
 
 #[cfg(test)]
 pub(super) mod tests {
-    use std::time::Duration;
 
     use super::*;
 
-    use ureq::{self, AgentBuilder};
+    use mockall::{mock, predicate::*};
 
-    /// Ureq implementation of HttpClient
-    pub struct HttpClientUreq {
-        agent: ureq::Agent,
-    }
+    // Create a mock for the HttpClient trait using the mock! macro
+    mock! {
+        pub HttpClient {}
 
-    impl HttpClientUreq {
-        pub fn new(timeout: Duration) -> Self {
-            Self {
-                agent: AgentBuilder::new()
-                    .timeout_connect(timeout)
-                    .timeout(timeout)
-                    .build(),
-            }
+        impl HttpClient for HttpClient {
+            fn send(&self, req: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, HttpClientError>;
         }
-    }
-
-    impl HttpClient for HttpClientUreq {
-        fn send(&self, request: Request<Vec<u8>>) -> Result<Response<Vec<u8>>, HttpClientError> {
-            // Build the ureq request from the agent to get the configs set in there.
-            // The .into() method from conversion would create a new agent per request so we avoid that.
-            let mut req = self.agent.request(
-                request.method().as_str(),
-                request.uri().to_string().as_str(),
-            );
-
-            for (header_name, header_value) in request.headers() {
-                let header_val = header_value.to_str().map_err(|e| {
-                    HttpClientError::EncoderError(format!("setting request header: {e}"))
-                })?;
-                req = req.set(header_name.as_str(), header_val);
-            }
-
-            match req.send_bytes(request.body()) {
-                Ok(response) | Err(ureq::Error::Status(_, response)) => build_response(response),
-
-                Err(ureq::Error::Transport(e)) => {
-                    Err(HttpClientError::TransportError(e.to_string()))
-                }
-            }
-        }
-    }
-
-    fn build_response(response: ureq::Response) -> Result<Response<Vec<u8>>, HttpClientError> {
-        let http_version = match response.http_version() {
-            "HTTP/0.9" => http::Version::HTTP_09,
-            "HTTP/1.0" => http::Version::HTTP_10,
-            "HTTP/1.1" => http::Version::HTTP_11,
-            "HTTP/2.0" => http::Version::HTTP_2,
-            "HTTP/3.0" => http::Version::HTTP_3,
-            _ => unreachable!(),
-        };
-
-        let response_builder = http::Response::builder()
-            .status(response.status())
-            .version(http_version);
-
-        let mut buf: Vec<u8> = vec![];
-        response
-            .into_reader()
-            .read_to_end(&mut buf)
-            .map_err(|e| HttpClientError::InvalidResponse(e.to_string()))?;
-
-        response_builder
-            .body(buf)
-            .map_err(|e| HttpClientError::InvalidResponse(e.to_string()))
     }
 }


### PR DESCRIPTION
Removed the ureq dev dependency. After the http client unification on AC this test strategy doesn't make much sense. 