### PR TITLE
style: test utilities and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,18 +997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mockall_double"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1ca96e5ac35256ae3e13536edd39b172b88f41615e1d7b653c8ad24524113e8"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1046,7 +1034,6 @@ dependencies = [
  "http",
  "jsonwebtoken",
  "mockall",
- "mockall_double",
  "rcgen",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2157,7 +2157,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 jsonwebtoken = "9"
-url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v7"] }
 tracing = "0.1"
 http = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ rcgen = { version = "0.13", features = ["aws_lc_rs"] }
 [dev-dependencies]
 assert_matches = "1.5.0"
 mockall = "0.13.1"
-mockall_double = "0.3.1"
 url = "2"
 http = "1"
 thiserror = "2"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,7 +10,7 @@ either by [opening an issue](https://github.com/newrelic/newrelic-auth-rs/issues
 or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 
 For any licenses that require the disclosure of source code, the source code
-can be found at https://github.com/newrelic/newrelic-auth-rs.
+can be found at <https://github.com/newrelic/newrelic-auth-rs>.
 
 ## aho-corasick <https://crates.io/crates/aho-corasick>
 
@@ -143,13 +143,6 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
-## displaydoc <https://crates.io/crates/displaydoc>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
 ## dunce <https://crates.io/crates/dunce>
 
 Distributed under the following license(s):
@@ -178,13 +171,6 @@ Distributed under the following license(s):
 
 * Apache-2.0
 * MIT
-
-## form_urlencoded <https://crates.io/crates/form_urlencoded>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
 
 ## fs_extra <https://crates.io/crates/fs_extra>
 
@@ -233,62 +219,6 @@ Distributed under the following license(s):
 
 * MIT
 * Apache-2.0
-
-## icu_collections <https://crates.io/crates/icu_collections>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_locale_core <https://crates.io/crates/icu_locale_core>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_normalizer <https://crates.io/crates/icu_normalizer>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_normalizer_data <https://crates.io/crates/icu_normalizer_data>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_properties <https://crates.io/crates/icu_properties>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_properties_data <https://crates.io/crates/icu_properties_data>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## icu_provider <https://crates.io/crates/icu_provider>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## idna <https://crates.io/crates/idna>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
-## idna_adapter <https://crates.io/crates/idna_adapter>
-
-Distributed under the following license(s):
-
-* Apache-2.0
-* MIT
 
 ## itertools <https://crates.io/crates/itertools>
 
@@ -359,12 +289,6 @@ Distributed under the following license(s):
 * Apache-2.0
 * MIT
 
-## litemap <https://crates.io/crates/litemap>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
 ## log <https://crates.io/crates/log>
 
 Distributed under the following license(s):
@@ -433,25 +357,12 @@ Distributed under the following license(s):
 
 * MIT
 
-## percent-encoding <https://crates.io/crates/percent-encoding>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
 ## pin-project-lite <https://crates.io/crates/pin-project-lite>
 
 Distributed under the following license(s):
 
 * Apache-2.0
 * MIT
-
-## potential_utf <https://crates.io/crates/potential_utf>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
 
 ## powerfmt <https://crates.io/crates/powerfmt>
 
@@ -594,32 +505,12 @@ Distributed under the following license(s):
 
 * ISC
 
-## smallvec <https://crates.io/crates/smallvec>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
-## stable_deref_trait <https://crates.io/crates/stable_deref_trait>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
 ## syn <https://crates.io/crates/syn>
 
 Distributed under the following license(s):
 
 * MIT
 * Apache-2.0
-
-## synstructure <https://crates.io/crates/synstructure>
-
-Distributed under the following license(s):
-
-* MIT
 
 ## thiserror <https://crates.io/crates/thiserror>
 
@@ -656,12 +547,6 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
-## tinystr <https://crates.io/crates/tinystr>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
 ## tracing <https://crates.io/crates/tracing>
 
 Distributed under the following license(s):
@@ -693,20 +578,6 @@ Distributed under the following license(s):
 Distributed under the following license(s):
 
 * ISC
-
-## url <https://crates.io/crates/url>
-
-Distributed under the following license(s):
-
-* MIT
-* Apache-2.0
-
-## utf8_iter <https://crates.io/crates/utf8_iter>
-
-Distributed under the following license(s):
-
-* Apache-2.0
-* MIT
 
 ## uuid <https://crates.io/crates/uuid>
 
@@ -884,12 +755,6 @@ Distributed under the following license(s):
 * Apache-2.0
 * MIT
 
-## writeable <https://crates.io/crates/writeable>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
 ## yasna <https://crates.io/crates/yasna>
 
 Distributed under the following license(s):
@@ -897,51 +762,9 @@ Distributed under the following license(s):
 * MIT
 * Apache-2.0
 
-## yoke <https://crates.io/crates/yoke>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## yoke-derive <https://crates.io/crates/yoke-derive>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## zerofrom <https://crates.io/crates/zerofrom>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## zerofrom-derive <https://crates.io/crates/zerofrom-derive>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
 ## zeroize <https://crates.io/crates/zeroize>
 
 Distributed under the following license(s):
 
 * Apache-2.0
 * MIT
-
-## zerotrie <https://crates.io/crates/zerotrie>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## zerovec <https://crates.io/crates/zerovec>
-
-Distributed under the following license(s):
-
-* Unicode-3.0
-
-## zerovec-derive <https://crates.io/crates/zerovec-derive>
-
-Distributed under the following license(s):
-
-* Unicode-3.0

--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -10,7 +10,7 @@ either by [opening an issue](https://github.com/newrelic/newrelic-auth-rs/issues
 or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 
 For any licenses that require the disclosure of source code, the source code
-can be found at https://github.com/newrelic/newrelic-auth-rs.
+can be found at <https://github.com/newrelic/newrelic-auth-rs>.
 {% for dep, licenseObj in dependencies %}
 {%- if dep is containing("nr-auth") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>

--- a/examples/jwt-signer-local/main.rs
+++ b/examples/jwt-signer-local/main.rs
@@ -1,12 +1,11 @@
 //! Example to sign a JWT token using a local private key
 use std::env;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use url::Url;
 
 use chrono::{TimeDelta, Utc};
 use dotenvy::dotenv;
 
+use http::Uri;
 use nr_auth::jwt::claims::Claims;
 use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 use nr_auth::jwt::signer::{JwtSigner, JwtSignerImpl};
@@ -39,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let private_key_path = env::var("PRIVATE_KEY_PATH")?;
     let client_id = env::var("CLIENT_ID")?;
-    let url = Url::from_str(DEFAULT_AUDIENCE).expect("constant valid url value");
+    let url = Uri::try_from(DEFAULT_AUDIENCE).expect("constant valid url value");
 
     let signer = LocalPrivateKeySigner::try_from(PathBuf::from(private_key_path).as_path())?;
     let jwt_signer = JwtSignerImpl::Local(signer);

--- a/examples/jwt-signer-vault/main.rs
+++ b/examples/jwt-signer-vault/main.rs
@@ -1,16 +1,15 @@
 //! Example to sign a JWT token using Vault
 use std::env;
 use std::path::Path;
-use std::str::FromStr;
 
 use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
 use chrono::{TimeDelta, Utc};
 use dotenvy::dotenv;
+use http::Uri;
 use jsonwebtoken::{Algorithm, Header};
 use sha2::{Digest, Sha512};
 use tracing::debug;
-use url::Url;
 use vaultrs::api::transit::requests::SignDataRequestBuilder;
 use vaultrs::api::transit::MarshalingAlgorithm;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
@@ -65,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .map_err(|e| format!("cannot build vault client {}", e))?;
 
     // Build claims
-    let url = Url::from_str(DEFAULT_AUDIENCE).expect("constant valid url value");
+    let url = Uri::try_from(DEFAULT_AUDIENCE).expect("constant valid url value");
     let expires_at = Utc::now() + DEFAULT_JWT_CLAIM_EXP;
     let timestamp = expires_at
         .timestamp()

--- a/examples/retrieve-token/client.rs
+++ b/examples/retrieve-token/client.rs
@@ -86,11 +86,12 @@ fn try_build_response(res: BlockingResponse) -> Result<HttpResponse<Vec<u8>>, Ht
         .map_err(|err| HttpResponseError::ReadingResponse(err.to_string()))?
         .into();
 
-    let mut response_builder = http::Response::builder().status(status).version(version);
-
-    if let Some(tls_info) = tls_info {
-        response_builder = response_builder.extension(tls_info);
-    }
+    let response_builder = http::Response::builder().status(status).version(version);
+    let response_builder = if let Some(tls_info) = tls_info {
+        response_builder.extension(tls_info)
+    } else {
+        response_builder
+    };
 
     let response = response_builder
         .body(body)

--- a/examples/retrieve-token/main.rs
+++ b/examples/retrieve-token/main.rs
@@ -9,6 +9,7 @@ mod client;
 
 use client::HttpClient;
 use dotenvy::dotenv;
+use http::Uri;
 use nr_auth::authenticator::HttpAuthenticator;
 use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 use nr_auth::jwt::signer::JwtSignerImpl;
@@ -16,7 +17,6 @@ use nr_auth::token_retriever::TokenRetrieverWithCache;
 use nr_auth::TokenRetriever;
 use std::env;
 use std::path::{Path, PathBuf};
-use url::Url;
 
 /// Main function to retrieve and print an access token.
 /// It requires the following environment variables to be set:
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let jwt_signer = JwtSignerImpl::Local(signer);
 
     let client = HttpClient::new()?;
-    let authenticator = HttpAuthenticator::new(client, Url::parse(&token_url)?);
+    let authenticator = HttpAuthenticator::new(client, Uri::try_from(&token_url)?);
 
     let token_retriever = TokenRetrieverWithCache::new(client_id, jwt_signer, authenticator);
     let token = token_retriever.retrieve()?;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -24,16 +24,16 @@ pub trait Authenticator {
 }
 
 /// The Authenticator is responsible for obtaining a valid JWT token from System Identity Service.
-pub struct HttpAuthenticator<C> {
+pub struct HttpAuthenticator<C: HttpClient> {
     /// HTTP client
     http_client: C,
     /// System Identity Service URL
     url: Url,
 }
 
-impl<C> HttpAuthenticator<C> {
-    pub fn new(http_client: C, url: Url) -> Self {
-        Self { http_client, url }
+impl<C: HttpClient> HttpAuthenticator<C> {
+    pub fn new(http_client: C, uri: Uri) -> Self {
+        Self { http_client, uri }
     }
 }
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -22,7 +22,10 @@ pub enum AuthenticateError {
 }
 
 pub trait Authenticator {
-    fn authenticate(&self, req: Request) -> Result<TokenRetrievalResponse, AuthenticateError>;
+    fn authenticate(
+        &self,
+        req: TokenRetrievalRequest,
+    ) -> Result<TokenRetrievalResponse, AuthenticateError>;
 }
 
 /// The Authenticator is responsible for obtaining a valid JWT token from System Identity Service.
@@ -50,7 +53,10 @@ impl<C: HttpClient> fmt::Debug for HttpAuthenticator<C> {
 
 impl<C: HttpClient> Authenticator for HttpAuthenticator<C> {
     /// Executes a POST request to Authentication Server with the `Request` as a body and returns a `Response`.
-    fn authenticate(&self, req: Request) -> Result<TokenRetrievalResponse, AuthenticateError> {
+    fn authenticate(
+        &self,
+        req: TokenRetrievalRequest,
+    ) -> Result<TokenRetrievalResponse, AuthenticateError> {
         let serialized_req = serde_json::to_string(&req).map_err(|e| {
             AuthenticateError::SerializeError(format!("serializing request body: {e}"))
         })?;
@@ -98,7 +104,7 @@ pub enum ClientAssertionType {
 type ClientAssertion = String;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Request {
+pub struct TokenRetrievalRequest {
     pub client_id: ClientID,
     pub grant_type: GrantType,
     pub client_assertion_type: ClientAssertionType,
@@ -121,8 +127,8 @@ pub mod test {
     use mockall::mock;
 
     use super::{
-        ClientAssertion, ClientAssertionType, ClientID, GrantType, HttpAuthenticator, Request,
-        TokenRetrievalResponse,
+        ClientAssertion, ClientAssertionType, ClientID, GrantType, HttpAuthenticator,
+        TokenRetrievalRequest, TokenRetrievalResponse,
     };
     use crate::{
         authenticator::{AuthenticateError, Authenticator},
@@ -134,7 +140,7 @@ pub mod test {
 
         impl Authenticator for AuthenticatorMock
         {
-            fn authenticate(&self, req: Request) -> Result<TokenRetrievalResponse, AuthenticateError>;
+            fn authenticate(&self, req: TokenRetrievalRequest) -> Result<TokenRetrievalResponse, AuthenticateError>;
         }
     }
 
@@ -237,7 +243,7 @@ pub mod test {
 
     #[test]
     fn test_request_serialization_and_deserialization() {
-        let request = Request {
+        let request = TokenRetrievalRequest {
             client_assertion: ClientAssertion::from("fake_assertion"),
             client_assertion_type: ClientAssertionType::JwtBearer,
             client_id: ClientID::from("fake_id"),
@@ -255,9 +261,9 @@ pub mod test {
         Uri::try_from(TEST_URL).unwrap()
     }
 
-    fn fake_request_response() -> (Request, TokenRetrievalResponse) {
+    fn fake_request_response() -> (TokenRetrievalRequest, TokenRetrievalResponse) {
         (
-            Request {
+            TokenRetrievalRequest {
                 client_id: ClientID::from("fake_id"),
                 grant_type: GrantType::ClientCredentials,
                 client_assertion_type: ClientAssertionType::JwtBearer,

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -37,10 +37,16 @@ impl<C: HttpClient> HttpAuthenticator<C> {
     }
 }
 
-impl<C> Authenticator for HttpAuthenticator<C>
-where
-    C: HttpClient,
-{
+impl<C: HttpClient> fmt::Debug for HttpAuthenticator<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpAuthenticator")
+            .field("http_client", &"impl HttpClient")
+            .field("uri", &self.uri)
+            .finish()
+    }
+}
+
+impl<C: HttpClient> Authenticator for HttpAuthenticator<C> {
     /// Executes a POST request to Authentication Server with the `Request` as a body and returns a `Response`.
     fn authenticate(&self, req: Request) -> Result<Response, AuthenticateError> {
         let serialized_req = serde_json::to_string(&req).map_err(|e| {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -17,7 +17,7 @@ pub enum HttpClientError {
     /// Represents a compression error.
     #[error("error compressing data: `{0}`")]
     CompressionError(String),
-    /// Represents a compression error.
+    /// Represents an unexpected response.
     #[error("invalid http response: `{0}`")]
     InvalidResponse(String),
 }

--- a/src/jwt/claims.rs
+++ b/src/jwt/claims.rs
@@ -1,5 +1,5 @@
+use http::Uri;
 use serde::{Deserialize, Serialize};
-use url::Url;
 use uuid::Uuid;
 
 /// JWT Claims supported by the service.
@@ -32,7 +32,7 @@ impl Clone for Claims {
 
 impl Claims {
     /// Create a new Claims instance
-    pub fn new(client_id: String, aud: Url, exp: u64) -> Self {
+    pub fn new(client_id: String, aud: Uri, exp: u64) -> Self {
         Self {
             iss: client_id.clone(),
             sub: client_id,

--- a/src/jwt/signer.rs
+++ b/src/jwt/signer.rs
@@ -16,7 +16,6 @@ pub enum JwtSignerImpl {
     Local(LocalPrivateKeySigner),
 }
 
-#[cfg_attr(test, mockall::automock)]
 impl JwtSigner for JwtSignerImpl {
     fn sign(&self, claims: Claims) -> Result<SignedJwt, JwtEncoderError> {
         match self {

--- a/src/jwt/signer.rs
+++ b/src/jwt/signer.rs
@@ -30,3 +30,18 @@ pub enum JwtSignerImplError {
     #[error("building local private key JWT signer: `{0}`")]
     LocalPrivateKeySignerError(#[from] LocalPrivateKeySignerError),
 }
+
+#[cfg(test)]
+pub mod tests {
+    use mockall::mock;
+
+    use super::*;
+
+    mock! {
+        pub JwtSigner {}
+
+        impl JwtSigner for JwtSigner {
+            fn sign(&self, claims: Claims) -> Result<SignedJwt, JwtEncoderError>;
+        }
+    }
+}

--- a/src/jwt/signer.rs
+++ b/src/jwt/signer.rs
@@ -12,6 +12,7 @@ pub trait JwtSigner {
 }
 
 /// Enumerates all implementations for `JwtSigner` for static dispatching reasons.
+#[derive(Debug)]
 pub enum JwtSignerImpl {
     Local(LocalPrivateKeySigner),
 }

--- a/src/jwt/signer/local.rs
+++ b/src/jwt/signer/local.rs
@@ -31,15 +31,15 @@ impl Debug for LocalPrivateKeySigner {
 }
 
 /// Attempt to create a LocalPrivateKeySigner from a PemFileContents.
-impl TryFrom<Vec<u8>> for LocalPrivateKeySigner {
+impl TryFrom<&[u8]> for LocalPrivateKeySigner {
     type Error = LocalPrivateKeySignerError;
 
-    fn try_from(pem: Vec<u8>) -> Result<Self, Self::Error> {
+    fn try_from(pem: &[u8]) -> Result<Self, Self::Error> {
         // Algorithm is hardcoded to RS256, so decoding key is also fixed. Here we load it from
         // a PEM file.
         Ok(Self {
             // This will call pem::parse
-            encoding_key: EncodingKey::from_rsa_pem(pem.as_ref())?,
+            encoding_key: EncodingKey::from_rsa_pem(pem)?,
             algorithm: Algorithm::RS256,
         })
     }
@@ -51,7 +51,7 @@ impl TryFrom<&Path> for LocalPrivateKeySigner {
 
     fn try_from(path: &Path) -> Result<Self, Self::Error> {
         let pem = std::fs::read(path)?;
-        Self::try_from(pem)
+        Self::try_from(pem.as_slice())
     }
 }
 
@@ -67,12 +67,12 @@ impl JwtSigner for LocalPrivateKeySigner {
 }
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use super::*;
     use jsonwebtoken::{get_current_timestamp, DecodingKey, Validation};
     use url::Url;
 
-    const RS256_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+    pub const RS256_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
 MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQC2PaghXmD7Sctw
 HHkkF3yDkBlemb1qWKt6Io8GW7OlYSJ60HDJtJXrQ3woIcKgr1ammaXE1aMliUHW
 LclLvh5x00e6eNpTrnKEpXrhe139VM2QrgGwp2glNHttTEbTExLBHSEcY6tx6g4Z
@@ -133,8 +133,7 @@ BrPkB8yrZjJU/fpF2D6HzGfinKRboBTcmo7mUF2wuYARj/IsuEklh0gz7rseIf7G
         validation.set_required_spec_claims(&["exp", "sub", "aud"]);
 
         // Create local signer
-        let signer =
-            LocalPrivateKeySigner::try_from(RS256_PRIVATE_KEY.as_bytes().to_vec()).unwrap();
+        let signer = LocalPrivateKeySigner::try_from(RS256_PRIVATE_KEY.as_bytes()).unwrap();
 
         // Sign the token
         let signed_jwt = signer.sign(claims);
@@ -158,7 +157,7 @@ BrPkB8yrZjJU/fpF2D6HzGfinKRboBTcmo7mUF2wuYARj/IsuEklh0gz7rseIf7G
 
     #[test]
     fn bad_pem_file() {
-        let signer = LocalPrivateKeySigner::try_from("WRONG".as_bytes().to_vec());
+        let signer = LocalPrivateKeySigner::try_from("WRONG".as_bytes());
         assert!(signer.is_err());
     }
 }

--- a/src/jwt/signer/local.rs
+++ b/src/jwt/signer/local.rs
@@ -69,8 +69,8 @@ impl JwtSigner for LocalPrivateKeySigner {
 #[cfg(test)]
 pub mod test {
     use super::*;
+    use http::Uri;
     use jsonwebtoken::{get_current_timestamp, DecodingKey, Validation};
-    use url::Url;
 
     pub const RS256_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
 MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQC2PaghXmD7Sctw
@@ -116,7 +116,7 @@ BrPkB8yrZjJU/fpF2D6HzGfinKRboBTcmo7mUF2wuYARj/IsuEklh0gz7rseIf7G
     #[test]
     fn local_private_key_signer_rsa() {
         // Set expected claims content
-        let audience = Url::parse("http://127.0.0.1/").unwrap();
+        let audience = Uri::try_from("http://127.0.0.1/").unwrap();
         let client_id = "test"; // For both issuer and subject
 
         // Claims

--- a/src/jwt/signer/local.rs
+++ b/src/jwt/signer/local.rs
@@ -1,5 +1,5 @@
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
-use std::{io, path::Path};
+use std::{fmt::Debug, io, path::Path};
 use thiserror::Error;
 
 use crate::jwt::{claims::Claims, error::JwtEncoderError, signed::SignedJwt};
@@ -19,6 +19,15 @@ pub enum LocalPrivateKeySignerError {
 pub struct LocalPrivateKeySigner {
     encoding_key: EncodingKey,
     algorithm: Algorithm,
+}
+
+impl Debug for LocalPrivateKeySigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalPrivateKeySigner")
+            .field("algorithm", &self.algorithm)
+            .field("encoding_key", &"REDACTED") // Avoid printing the key
+            .finish()
+    }
 }
 
 /// Attempt to create a LocalPrivateKeySigner from a PemFileContents.

--- a/src/key/creator.rs
+++ b/src/key/creator.rs
@@ -21,7 +21,7 @@ pub struct KeyPair {
 
 /// A trait for creating cryptographic keys.
 pub trait Creator {
-    type Error;
+    type Error: std::error::Error;
     /// Creates and persists a cryptographic key based on the provided options. The created private
     /// key will not be accessible/exposed. Depending on the implementation it could be accessible
     /// (i.e. Local key pair) but others like Vault, KMS... will not. In any case, the private key
@@ -29,4 +29,23 @@ pub trait Creator {
     ///
     /// Return created public key in PEM format, or an error if key creation fails.
     fn create(&self) -> Result<PublicKeyPem, Self::Error>;
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use mockall::mock;
+    use thiserror::Error;
+
+    #[derive(Debug, Error)]
+    #[error("mock creator error")]
+    pub struct MockCreatorError;
+
+    mock! {
+        pub Creator {}
+        impl Creator for Creator {
+            type Error = MockCreatorError;
+            fn create(&self) -> Result<PublicKeyPem, MockCreatorError>;
+        }
+    }
 }

--- a/src/key/local.rs
+++ b/src/key/local.rs
@@ -62,15 +62,23 @@ impl Creator for LocalCreator {
     }
 }
 
-impl LocalCreator {
-    pub fn new(config: KeyPairGeneratorLocalConfig) -> Self {
+impl From<KeyPairGeneratorLocalConfig> for LocalCreator {
+    fn from(
+        KeyPairGeneratorLocalConfig {
+            key_type,
+            name,
+            path,
+        }: KeyPairGeneratorLocalConfig,
+    ) -> Self {
         Self {
-            key_type: config.key_type,
-            name: config.name,
-            path: config.path,
+            key_type,
+            name,
+            path,
         }
     }
+}
 
+impl LocalCreator {
     /// Persists the private key to the specified file path.
     fn persist_private_key(&self, key: &[u8]) -> Result<(), LocalKeyCreationError> {
         debug!(
@@ -152,7 +160,7 @@ mod tests {
             name: "key".to_string(),
             path: key_path.clone(),
         };
-        let creator = LocalCreator::new(config);
+        let creator = LocalCreator::from(config);
         let result = creator.create();
         assert_matches!(
             result,
@@ -170,7 +178,7 @@ mod tests {
             name: "key".to_string(),
             path: tmp_file.path().to_path_buf(),
         };
-        let creator = LocalCreator::new(config);
+        let creator = LocalCreator::from(config);
         let result = creator.create();
         assert_matches!(
             result,
@@ -192,7 +200,7 @@ mod tests {
             path: key_path.to_path_buf(),
         };
 
-        let creator = LocalCreator::new(config);
+        let creator = LocalCreator::from(config);
 
         let pub_key = creator.create().expect("Failed to create key pair");
         let pub_key_content =

--- a/src/key/local.rs
+++ b/src/key/local.rs
@@ -182,15 +182,14 @@ mod tests {
 
     #[test]
     fn test_local_creator_create() {
-        let key_path = TempDir::new()
-            .expect("Failed to create temp directory")
-            .into_path();
+        let tmp_dir = TempDir::new().expect("Failed to create temp directory");
+        let key_path = tmp_dir.path();
 
         let key_name = String::from("key");
         let config = KeyPairGeneratorLocalConfig {
             key_type: KeyType::Rsa4096,
             name: key_name.clone(),
-            path: key_path.clone(),
+            path: key_path.to_path_buf(),
         };
 
         let creator = LocalCreator::new(config);

--- a/src/token.rs
+++ b/src/token.rs
@@ -14,6 +14,17 @@ pub struct Token {
     token_type: TokenType,
 }
 
+impl TryFrom<&str> for TokenType {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "Bearer" | "bearer" => Ok(TokenType::Bearer),
+            _ => Err(format!("Invalid token type: {value}")),
+        }
+    }
+}
+
 impl Token {
     pub fn new(
         access_token: AccessToken,

--- a/src/token_retriever.rs
+++ b/src/token_retriever.rs
@@ -4,10 +4,9 @@ use crate::jwt::signer::JwtSigner;
 use crate::token::Token;
 use crate::{ClientID, TokenRetriever, TokenRetrieverError};
 use chrono::{TimeDelta, Utc};
-use std::str::FromStr;
+use http::Uri;
 use std::sync::Mutex;
 use tracing::debug;
-use url::Url;
 
 /// A signed JWT should live enough for the System Identity Service to consume it.
 const DEFAULT_JWT_CLAIM_EXP: TimeDelta = TimeDelta::seconds(180);
@@ -21,7 +20,7 @@ where
     J: JwtSigner,
 {
     client_id: ClientID,
-    aud: Url,
+    aud: Uri,
     tokens: Mutex<Option<Token>>,
     jwt_signer: J,
     authenticator: A,
@@ -87,7 +86,7 @@ where
     ) -> TokenRetrieverWithCache<A, J> {
         TokenRetrieverWithCache {
             client_id,
-            aud: Url::from_str(DEFAULT_AUDIENCE).expect("constant valid url value"),
+            aud: Uri::try_from(DEFAULT_AUDIENCE).expect("constant valid url value"),
             tokens: Mutex::new(None),
             jwt_signer,
             authenticator,

--- a/src/token_retriever.rs
+++ b/src/token_retriever.rs
@@ -138,20 +138,30 @@ mod test {
     use std::{thread, time};
 
     use chrono::{TimeDelta, Utc};
+    use mockall::mock;
     use mockall::{predicate::eq, Sequence};
 
-    use crate::authenticator::{test::MockAuthenticatorMock, TokenRetrievalResponse};
-    #[cfg_attr(test, mockall_double::double)]
-    use crate::jwt::signer::JwtSignerImpl;
+    use crate::authenticator::test::MockAuthenticatorMock;
+
+    use crate::jwt::signer::tests::MockJwtSigner;
     use crate::{
-        authenticator::{AuthenticateError, ClientAssertionType, GrantType, Request},
+        authenticator::{
+            AuthenticateError, ClientAssertionType, GrantType, Request, TokenRetrievalResponse,
+        },
         jwt::signed::SignedJwt,
         token::{Token, TokenType},
         token_retriever::DEFAULT_JWT_CLAIM_EXP,
-        TokenRetriever,
+        TokenRetriever, TokenRetrieverError,
     };
 
     use super::{TokenRetrieverWithCache, DEFAULT_AUDIENCE};
+
+    mock! {
+        pub TokenRetriever {}
+        impl TokenRetriever for TokenRetriever {
+            fn retrieve(&self) -> Result<Token, TokenRetrieverError>;
+        }
+    }
 
     #[test]
     // Test that a new token is retrieved when there is no cache and a cached token is
@@ -163,7 +173,7 @@ mod test {
         let fake_client_assertion = "client_assertion";
         let fake_token = "fakeToken";
 
-        let mut jwt_signer = JwtSignerImpl::new();
+        let mut jwt_signer = MockJwtSigner::new();
         jwt_signer
             .expect_sign()
             .once()
@@ -227,7 +237,7 @@ mod test {
         let client_id = "client_id";
         let token_expires_in = 2;
 
-        let mut jwt_signer = JwtSignerImpl::new();
+        let mut jwt_signer = MockJwtSigner::new();
         jwt_signer.expect_sign().times(2).returning(move |_| {
             Ok(SignedJwt {
                 value: "client_assertion".into(),
@@ -267,7 +277,7 @@ mod test {
     fn no_retries_and_fail_calls_retrieve_once() {
         let client_id = "client_id";
 
-        let mut jwt_signer = JwtSignerImpl::new();
+        let mut jwt_signer = MockJwtSigner::new();
         // This actually tests TokenRetrieverWithCache's `refresh_token`.
         // Calling `retrieve` makes calls to both first `sign` and then to `authenticate`.
         // We instruct the `authenticate` call to fail every time and check that `sign` is called only the number of times we expect.
@@ -303,7 +313,7 @@ mod test {
         let fake_token = "fake";
         let token_expires_in = 5;
 
-        let mut jwt_signer = JwtSignerImpl::new();
+        let mut jwt_signer = MockJwtSigner::new();
         // This actually tests TokenRetrieverWithCache's `refresh_token`.
         // Calling `retrieve` makes calls to both first `sign` and then to `authenticate`.
         // We instruct the `authenticate` call to fail every time and check that `sign` is called only the number of times we expect.
@@ -360,7 +370,7 @@ mod test {
     fn retries_fail() {
         let client_id = "client_id";
 
-        let mut jwt_signer = JwtSignerImpl::new();
+        let mut jwt_signer = MockJwtSigner::new();
         // This actually tests TokenRetrieverWithCache's `refresh_token`. Calling `retrieve` makes calls to both first `sign` and then to `authenticate`. We instruct the `authenticate` call to fail every time and check that `sign` is called only the number of times we expect.
         jwt_signer.expect_sign().times(3).returning(move |_| {
             Ok(SignedJwt {

--- a/src/token_retriever.rs
+++ b/src/token_retriever.rs
@@ -1,4 +1,4 @@
-use crate::authenticator::{Authenticator, ClientAssertionType, GrantType, Request};
+use crate::authenticator::{Authenticator, ClientAssertionType, GrantType, TokenRetrievalRequest};
 use crate::jwt::claims::Claims;
 use crate::jwt::signer::JwtSigner;
 use crate::token::Token;
@@ -115,7 +115,7 @@ where
 
         let signed_jwt = self.jwt_signer.sign(claims)?;
 
-        let request = Request {
+        let request = TokenRetrievalRequest {
             client_id: self.client_id.to_owned(),
             grant_type: GrantType::ClientCredentials,
             client_assertion_type: ClientAssertionType::JwtBearer,
@@ -142,7 +142,8 @@ pub mod test {
     use crate::jwt::signer::tests::MockJwtSigner;
     use crate::{
         authenticator::{
-            AuthenticateError, ClientAssertionType, GrantType, Request, TokenRetrievalResponse,
+            AuthenticateError, ClientAssertionType, GrantType, TokenRetrievalRequest,
+            TokenRetrievalResponse,
         },
         jwt::signed::SignedJwt,
         token::{Token, TokenType},
@@ -185,7 +186,7 @@ pub mod test {
                 })
             });
 
-        let expected_request = Request {
+        let expected_request = TokenRetrievalRequest {
             client_id: client_id.to_owned(),
             grant_type: GrantType::ClientCredentials,
             client_assertion_type: ClientAssertionType::JwtBearer,


### PR DESCRIPTION
This lays the ground for subsequent PRs for the System Identity Creation implementation.

There are many commits, but they are really small and mostly self-contained changes, meant to be inspected individually if desired:

- Fixes some usage of generics. For example, `HttpAuthenticator` was generic over an arbitrary `C` instead of a `C: HttpClient`.
- Remove `url` as a dependency given we are already coupled to `http`, using the `http::Uri` type instead.
- Added mocks for the traits defined, removing a remaining usage of `mockall_double`.
- Modify usage of some functions e.g. deprecated methods in some tests, `From` implementations instead of pure and total `new` constructors taking one parameter and fully using it, address sources of panics in production code like computation of a `TimeDelta` in the presence of overflowing values.