### PR TITLE
feat: add jq to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,9 @@ ARG TARGETARCH
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get clean && \
-    apt-get install -y curl
+    apt-get clean
 
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl"
-RUN chmod +x kubectl && mv kubectl /usr/local/bin/kubectl
-
-RUN curl -Lo jq "https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-linux-${TARGETARCH}"
-RUN chmod +x jq && mv jq /usr/local/bin/jq
+RUN apt-get install -y curl kubectl jq
 
 COPY --chmod=755 target/newrelic-auth-cli-${TARGETARCH} /bin/newrelic-auth-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && \
     apt-get install -y curl
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl"
+RUN chmod +x kubectl && mv kubectl /usr/local/bin/kubectl
+
+RUN curl -Lo jq "https://github.com/jqlang/jq/releases/download/jq-1.8.0/jq-linux-${TARGETARCH}"
+RUN chmod +x jq && mv jq /usr/local/bin/jq
 
 COPY --chmod=755 target/newrelic-auth-cli-${TARGETARCH} /bin/newrelic-auth-cli
 


### PR DESCRIPTION
## What's the PR about

Adds `jq` to the dockerfile. Related to #NR-400537

## Context

We will use the image resulting of this Dockerfile in the [preinstallation job](https://github.com/newrelic/helm-charts/blob/master/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml). We need to make sure we have all the tools.
`kubectl` and the "nr auth cli" were already there, but we also need `jq`.

Another important detail is that `openssl` is needed until the cli replaces the script. However, the base docker image already includes it.

![Captura de pantalla 2025-06-04 a las 16 32 28](https://github.com/user-attachments/assets/917b4501-a6fb-43e4-90f4-8ed3da31062a)
