### PR TITLE
feat: change docker image name (NR-400537)

### DIFF
--- a/.github/workflows/component_image.yml
+++ b/.github/workflows/component_image.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build/Push images
     env:
-      DOCKER_IMAGE_NAME_AUTH: newrelic/newrelic-auth-cli
+      DOCKER_IMAGE_NAME_AUTH: newrelic/agent-control-system-identity-registration
       DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/component_image_security.yml
+++ b/.github/workflows/component_image_security.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 env:
-  DOCKER_IMAGE_NAME_AUTH: newrelic/newrelic-auth-cli
+  DOCKER_IMAGE_NAME_AUTH: newrelic/agent-control-system-identity-registration
   SEVERITY: 'CRITICAL,HIGH'
 
 jobs:

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Push container release tags
     env:
-      DOCKER_IMAGE_NAME_AUTH: newrelic/newrelic-auth-cli
+      DOCKER_IMAGE_NAME_AUTH: newrelic/agent-control-system-identity-registration
     steps:
       - uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
## What's the PR about

Changes the docker image name. Related to #NR-400537

## Context

We already had an image in Agent Control [repository](https://github.com/newrelic/newrelic-agent-control) with the tools required for the chart [preinstallation job](https://github.com/newrelic/helm-charts/blob/5ff8f1d5faa1e6bd5a187d098e7cde2a53962640/charts/agent-control-deployment/templates/preinstall-job-register-system-identity.yaml#L68). We added a docker image here for the nr auth repository.

We don't want to handle two images and two release pipelines at the moment. We want to start simple. We decided to use the docker image in this repository with the "old" name, and remove the new one. This avoids:

* Changing the docker image name in the installation job
* Potentially breaking old chart versions (if we decided to remove the "old" name and use the new one)
* Having two images in the docker repository, but only actively use one of them in newer versions

Maybe the docker image name is not the best for the new use case. Maybe the image is to centered on AC. Maybe we should put the pipeline in AC. We can start from here and improve things.

The alternative would be to update https://github.com/newrelic/newrelic-agent-control/blob/main/Dockerfiles/Dockerfile_system_identity_registration in AC and copy the pipelines improvements. Any feedback is welcome.