### PR TITLE
feat: align docker image with previous versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
-FROM debian:trixie-slim
+FROM alpine:3.22
 
 ARG TARGETARCH
 
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get clean
+RUN apk update && \
+    apk upgrade --no-cache
 
-RUN apt-get install -y curl kubectl jq
+RUN apk add --no-cache kubectl curl jq openssl
 
 COPY --chmod=755 target/newrelic-auth-cli-${TARGETARCH} /bin/newrelic-auth-cli
+
+RUN mkdir /gen-folder && chown nobody:nogroup /gen-folder
 
 USER nobody
 


### PR DESCRIPTION
### What's this PR about

Updating the docker file so that the resulting image is similar to previous versions used by the preinstall job template in the chart.

### Context

The original image is using alpine. The new image is using debian. They use different shells. To use the new image, we would need to update the preinstall job. That means, breaking changes. We would also have to coordinate in order to release the new helm release at the same time that we upload the new docker image. This is because the preinstallation job uses `latest` as the version for the image.

We decided to simplify things and have a single image and pipeline. Hence, I think it's sensible to use alpine as in the old image and make the appropiate changes to make it work. This means adding the `newrelic-auth-cli`.

I decided to keep @paologallinaharbur approach to use the `nobody` user. However, I added permissions to a specific folder that is required for the current preinstall job.

### Next steps

* We should pin the version of the image in the preinstall job. Otherwise, we will have potential issues with breaking changes in the future. We should avoid them as much as possible.

* This image might contain more binaries that what it needs once we replace the bash script. If we worked on the previous point. We could potentially remove some of the installed binaries in the future.

* If the first point is solved. We could also think about removing the permissions we are giving to `nobody` on the `gen-folder`.