### PR TITLE
chore: bump rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nr-auth"
 description = "Crate to manage NR System Identity Service authentication"
 version = "0.0.7"
-edition = "2021"
+edition = "2024"
 authors = ["The New Relic Agent Control Team"]
 publish = false
 license-file = "./LICENSE.md"

--- a/examples/generate-l1-si/main.rs
+++ b/examples/generate-l1-si/main.rs
@@ -5,9 +5,10 @@ use client::HttpClient;
 use dotenvy::dotenv;
 
 use nr_auth::authenticator::HttpAuthenticator;
-use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 use nr_auth::jwt::signer::JwtSignerImpl;
+use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 
+use nr_auth::TokenRetriever;
 use nr_auth::key::PrivateKeyPem;
 use nr_auth::system_identity::generator::L1SystemIdentityGenerator;
 use nr_auth::system_identity::iam_client::http::HttpIAMClient;
@@ -16,7 +17,6 @@ use nr_auth::system_identity::input_data::environment::NewRelicEnvironment;
 use nr_auth::system_identity::input_data::output_platform::OutputPlatform;
 use nr_auth::system_identity::input_data::{SystemIdentityCreationMetadata, SystemIdentityInput};
 use nr_auth::token_retriever::TokenRetrieverWithCache;
-use nr_auth::TokenRetriever;
 
 use std::path::{Path, PathBuf};
 use std::{env, fs, io};

--- a/examples/generate-l2-si/main.rs
+++ b/examples/generate-l2-si/main.rs
@@ -5,11 +5,12 @@ use client::HttpClient;
 use dotenvy::dotenv;
 
 use nr_auth::authenticator::HttpAuthenticator;
-use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 use nr_auth::jwt::signer::JwtSignerImpl;
+use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
 use nr_auth::key::creator::KeyType;
 use nr_auth::key::local::{KeyPairGeneratorLocalConfig, LocalCreator};
 
+use nr_auth::TokenRetriever;
 use nr_auth::key::PrivateKeyPem;
 use nr_auth::system_identity::generator::L2SystemIdentityGenerator;
 use nr_auth::system_identity::iam_client::http::HttpIAMClient;
@@ -18,7 +19,6 @@ use nr_auth::system_identity::input_data::environment::NewRelicEnvironment;
 use nr_auth::system_identity::input_data::output_platform::OutputPlatform;
 use nr_auth::system_identity::input_data::{SystemIdentityCreationMetadata, SystemIdentityInput};
 use nr_auth::token_retriever::TokenRetrieverWithCache;
-use nr_auth::TokenRetriever;
 
 use std::path::{Path, PathBuf};
 use std::{env, fs, io};

--- a/examples/jwt-signer-vault/main.rs
+++ b/examples/jwt-signer-vault/main.rs
@@ -2,16 +2,16 @@
 use std::env;
 use std::path::Path;
 
-use base64::prelude::BASE64_STANDARD;
 use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
 use chrono::{TimeDelta, Utc};
 use dotenvy::dotenv;
 use http::Uri;
 use jsonwebtoken::{Algorithm, Header};
 use sha2::{Digest, Sha512};
 use tracing::debug;
-use vaultrs::api::transit::requests::SignDataRequestBuilder;
 use vaultrs::api::transit::MarshalingAlgorithm;
+use vaultrs::api::transit::requests::SignDataRequestBuilder;
 use vaultrs::client::{VaultClient, VaultClientSettingsBuilder};
 use vaultrs::transit::data::sign;
 

--- a/examples/retrieve-token/main.rs
+++ b/examples/retrieve-token/main.rs
@@ -10,11 +10,11 @@ mod client;
 use client::HttpClient;
 use dotenvy::dotenv;
 use http::Uri;
-use nr_auth::authenticator::HttpAuthenticator;
-use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
-use nr_auth::jwt::signer::JwtSignerImpl;
-use nr_auth::token_retriever::TokenRetrieverWithCache;
 use nr_auth::TokenRetriever;
+use nr_auth::authenticator::HttpAuthenticator;
+use nr_auth::jwt::signer::JwtSignerImpl;
+use nr_auth::jwt::signer::local::LocalPrivateKeySigner;
+use nr_auth::token_retriever::TokenRetrieverWithCache;
 use std::env;
 use std::path::{Path, PathBuf};
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,14 +1,14 @@
 use core::fmt;
 
+use http::Uri;
 use http::header::CONTENT_TYPE;
 use http::method::Method;
-use http::Uri;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::http_client::HttpClient;
 use crate::system_identity::input_data::auth_method::ClientSecret;
-use crate::{token::AccessToken, ClientID};
+use crate::{ClientID, token::AccessToken};
 
 #[derive(Error, Debug)]
 pub enum AuthenticateError {
@@ -145,7 +145,7 @@ pub mod test {
     };
     use crate::{
         authenticator::{AuthenticateError, Authenticator},
-        http_client::{tests::MockHttpClient, HttpClientError},
+        http_client::{HttpClientError, tests::MockHttpClient},
     };
 
     mock! {

--- a/src/bin/main_cli.rs
+++ b/src/bin/main_cli.rs
@@ -1,4 +1,4 @@
-use std::process::{exit, ExitCode};
+use std::process::{ExitCode, exit};
 
 fn main() -> ExitCode {
     println!("I am the auth CLI");

--- a/src/jwt/signer/local.rs
+++ b/src/jwt/signer/local.rs
@@ -70,7 +70,7 @@ impl JwtSigner for LocalPrivateKeySigner {
 pub mod test {
     use super::*;
     use http::Uri;
-    use jsonwebtoken::{get_current_timestamp, DecodingKey, Validation};
+    use jsonwebtoken::{DecodingKey, Validation, get_current_timestamp};
 
     pub const RS256_PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
 MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQC2PaghXmD7Sctw

--- a/src/key/local.rs
+++ b/src/key/local.rs
@@ -1,6 +1,6 @@
 use crate::key::creator::{Creator, KeyPair, KeyType, PublicKeyPem};
 use rcgen::KeyPair as RcKeyPair;
-use rcgen::{RsaKeySize, PKCS_RSA_SHA512};
+use rcgen::{PKCS_RSA_SHA512, RsaKeySize};
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};

--- a/src/system_identity.rs
+++ b/src/system_identity.rs
@@ -59,23 +59,22 @@ impl ClientSecret {
 mod tests {
     use chrono::Utc;
     use mockall::Sequence;
-    use rstest::{rstest, Context};
+    use rstest::{Context, rstest};
     use std::path::PathBuf;
 
     use crate::{
         http_client::tests::MockHttpClient,
-        jwt::signer::local::{test::RS256_PRIVATE_KEY, LocalPrivateKeySigner},
+        jwt::signer::local::{LocalPrivateKeySigner, test::RS256_PRIVATE_KEY},
         key::creator::tests::MockCreator,
         system_identity::{
+            SystemIdentity,
             generator::L2SystemIdentityGenerator,
             iam_client::http::HttpIAMClient,
             identity_creator::tests::MockL2IAMClient,
             input_data::{
-                auth_method::ClientSecret, environment::NewRelicEnvironment,
-                output_platform::OutputPlatform, SystemIdentityCreationMetadata,
-                SystemIdentityInput,
+                SystemIdentityCreationMetadata, SystemIdentityInput, auth_method::ClientSecret,
+                environment::NewRelicEnvironment, output_platform::OutputPlatform,
             },
-            SystemIdentity,
         },
         token::{Token, TokenType},
         token_retriever::TokenRetrieverWithCache,
@@ -93,7 +92,7 @@ mod tests {
         #[context] ctx: Context,
         #[case] auth_method: AuthMethod,
     ) {
-        use crate::{authenticator::HttpAuthenticator, jwt::signer::JwtSignerImpl, TokenRetriever};
+        use crate::{TokenRetriever, authenticator::HttpAuthenticator, jwt::signer::JwtSignerImpl};
 
         let cli_input = SystemIdentityCreationMetadata {
             system_identity_input: SystemIdentityInput {

--- a/src/system_identity/generator.rs
+++ b/src/system_identity/generator.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 use crate::{key::creator::Creator as KeyCreator, token::Token};
 
 use super::{
-    identity_creator::{L1IdentityCreator, L2IdentityCreator},
     SystemIdentity,
+    identity_creator::{L1IdentityCreator, L2IdentityCreator},
 };
 
 /// This type is responsible for generating a System Identity and its associated key pair.

--- a/src/system_identity/iam_client/http.rs
+++ b/src/system_identity/iam_client/http.rs
@@ -1,17 +1,17 @@
-use base64::{engine::general_purpose, Engine};
+use base64::{Engine, engine::general_purpose};
 use http::{
-    header::{AUTHORIZATION, CONTENT_TYPE},
     HeaderValue, Request, StatusCode, Uri,
+    header::{AUTHORIZATION, CONTENT_TYPE},
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use crate::{
     http_client::HttpClient,
     system_identity::{
+        SystemIdentity,
         creation_response::SystemIdentityCreationResponse,
         identity_creator::{L1IdentityCreator, L2IdentityCreator},
         input_data::SystemIdentityCreationMetadata,
-        SystemIdentity,
     },
     token::Token,
 };

--- a/src/token.rs
+++ b/src/token.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, TimeDelta, Utc};
 
-use crate::{authenticator::TokenRetrievalResponse, TokenRetrieverError};
+use crate::{TokenRetrieverError, authenticator::TokenRetrievalResponse};
 
 pub type AccessToken = String;
 
@@ -81,9 +81,9 @@ impl TryFrom<TokenRetrievalResponse> for Token {
 mod test {
 
     use crate::{
+        TokenRetrieverError,
         authenticator::TokenRetrievalResponse,
         token::{AccessToken, Token, TokenType},
-        TokenRetrieverError,
     };
     use chrono::{Duration, Utc};
 

--- a/src/token_retriever.rs
+++ b/src/token_retriever.rs
@@ -5,7 +5,7 @@ use crate::token::Token;
 use crate::{ClientID, TokenRetriever, TokenRetrieverError};
 
 use ::http::Uri;
-use credential::{TokenCredential, DEFAULT_AUDIENCE};
+use credential::{DEFAULT_AUDIENCE, TokenCredential};
 use std::sync::Mutex;
 use tracing::debug;
 
@@ -139,7 +139,7 @@ pub mod test {
 
     use chrono::{TimeDelta, Utc};
     use mockall::mock;
-    use mockall::{predicate::eq, Sequence};
+    use mockall::{Sequence, predicate::eq};
 
     use crate::authenticator::test::MockAuthenticatorMock;
 
@@ -147,16 +147,16 @@ pub mod test {
     use crate::jwt::signer::tests::MockJwtSigner;
     use crate::token_retriever::credential::DEFAULT_JWT_CLAIM_EXP;
     use crate::{
+        TokenRetriever, TokenRetrieverError,
         authenticator::{
             AuthenticateError, ClientAssertionType, GrantType, TokenRetrievalRequest,
             TokenRetrievalResponse,
         },
         jwt::signed::SignedJwt,
         token::{Token, TokenType},
-        TokenRetriever, TokenRetrieverError,
     };
 
-    use super::{TokenRetrieverWithCache, DEFAULT_AUDIENCE};
+    use super::{DEFAULT_AUDIENCE, TokenRetrieverWithCache};
 
     mock! {
         pub TokenRetriever {}

--- a/src/token_retriever/credential.rs
+++ b/src/token_retriever/credential.rs
@@ -2,10 +2,10 @@ use chrono::{TimeDelta, Utc};
 use http::Uri;
 
 use crate::{
+    TokenRetrieverError,
     authenticator::{AuthCredential, ClientAssertionType},
     jwt::{claims::Claims, signer::JwtSigner},
     system_identity::input_data::auth_method::ClientSecret,
-    TokenRetrieverError,
 };
 
 /// A signed JWT should live enough for the System Identity Service to consume it.


### PR DESCRIPTION
Bumps the rust edition to 2024, it also includes the changes after performing `cargo fmt`