### PR TITLE
chore: remove `url` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,7 +1092,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
  "uuid",
  "vaultrs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ base64 = "0.22"
 [dev-dependencies]
 assert_matches = "1.5.0"
 mockall = "0.13.1"
-url = "2"
 http = "1"
 thiserror = "2"
 reqwest = { version = "0", default-features = false, features = [


### PR DESCRIPTION
I swear I had removed this while working on the SI implementation, but looking at #37 I saw it was still there. Just making sure it is removed since everything was moved to use `http::Uri` instead.