### PR TITLE
fix: change enums for environments and token output with alias

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -62,11 +62,11 @@ fn handle_authenticate_command(
     let retrieve_token_command = RetrieveTokenCommand::new(http_authenticator);
     let token = retrieve_token_command.retrieve_token(&meta)?;
     match output_token_format {
-        OutputTokenFormat::Plain => {
+        OutputTokenFormat::PLAIN => {
             println!("{}", token.access_token());
             Ok(())
         }
-        OutputTokenFormat::Json => {
+        OutputTokenFormat::JSON => {
             let output = serde_json::to_string_pretty(&token)?;
             println!("{}", output);
             Ok(())

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -81,11 +81,11 @@ pub struct AuthenticationArgs {
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
 pub enum OutputTokenFormat {
     /// Returns only the access token without type or expiration date
-    #[value(name = "Plain")]
-    Plain,
+    #[value(name = "PLAIN", alias = "Plain", alias = "plain")]
+    PLAIN,
     /// Returns full token information in json format
-    #[value(name = "Json")]
-    Json,
+    #[value(name = "JSON", alias = "Json", alias = "json")]
+    JSON,
 }
 
 #[derive(Args, Debug)]
@@ -120,12 +120,12 @@ pub struct BasicAuthArgs {
 
 #[derive(ValueEnum, Clone, Debug, PartialEq)]
 pub enum Environments {
-    #[value(name = "US")]
+    #[value(name = "US", alias = "Us", alias = "us")]
     US,
-    #[value(name = "EU")]
+    #[value(name = "EU", alias = "Eu", alias = "eu")]
     EU,
-    #[value(name = "Staging")]
-    Staging,
+    #[value(name = "STAGING", alias = "Staging", alias = "staging")]
+    STAGING,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -253,7 +253,7 @@ pub fn select_environment(environment: Environments) -> Result<NewRelicEnvironme
     match environment {
         Environments::US => Ok(NewRelicEnvironment::US),
         Environments::EU => Ok(NewRelicEnvironment::EU),
-        Environments::Staging => Ok(NewRelicEnvironment::Staging),
+        Environments::STAGING => Ok(NewRelicEnvironment::Staging),
     }
 }
 


### PR DESCRIPTION
Changing enums for environments and output token format to include alias with different options