### PR TITLE
feat: improve docker image health score (NR-424891)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get clean
 
-RUN apt-get install -y busybox curl kubectl jq
-RUN ln -s /bin/busybox /bin/ash
+RUN apt-get install -y curl jq
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${TARGETARCH}/kubectl"
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
 COPY --chmod=755 target/newrelic-auth-cli-${TARGETARCH} /bin/newrelic-auth-cli
+
+USER nobody
 
 ENTRYPOINT ["/bin/newrelic-auth-cli"]


### PR DESCRIPTION
Currently, the docker image has a health score of B. This PR tries pushing it to A.

Fixes #NR-424891

## Quick summary

We removed all solvable vulnerabilities and removed the use of root user. This PR can be merged, BUT the helm chart won't work if https://github.com/newrelic/helm-charts/pull/1785/files isn't merged.

Can't compute the health score locally. I hope this pushes it to A. If not, well, we improved it nonetheless.

## In-depth explanation

I can't assure the score will reach A score, because I couldn't find a way to compute it locally. Seems like we can only see the `docker scout` health score in the docker hub of newrelic. Not anywhere else. In any case, we had two issues:

* We were using the root user
* The image included critical or high level vulnerabilities in it that could be fixed

To solve the first issue, I had to modify the preinstallation job in the helm chart https://github.com/newrelic/helm-charts/pull/1785/files. We create a folder in the `/` foolder, which requires root user.

To solve the second issue I run `docker scout cves newrelic/agent-control-system-identity-registration` to find out which vulnerabilities could be fixed. There I saw, `pkg:golang/stdlib@1.24.1`. A dependency from k8s. Debian hasn't updated it on the image. To solve it, we have to manually install k8s. This was previously done by @paologallinaharbur. We moved it back to `apt` for simplicity. Now we know why we might want to install a dependency directly in some situations.

<img width="528" alt="Captura de pantalla 2025-07-03 a las 9 57 08" src="https://github.com/user-attachments/assets/1604917f-cc33-4e98-add7-7f3af7e108bb" />

I built the image locally, and analyzed it again with `docker scout cves auth-cli:latest`. We still have vulnerabilities, but there are no available solutions for them yet. For instance,

<img width="427" alt="Captura de pantalla 2025-07-03 a las 10 00 44" src="https://github.com/user-attachments/assets/9c0f6210-6c6d-4d9d-8a95-17b2ed8eb0a4" />

