### PR TITLE
refactor!: cli inputs

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,13 +5,10 @@ use nr_auth::commands::retrieve_token::RetrieveTokenCommand;
 use nr_auth::http::client::HttpClient;
 use nr_auth::http::config::HttpConfig;
 use nr_auth::parameters::{
-    AuthenticationArgs, Commands, DEFAULT_AUTHENTICATOR_TIMEOUT, IdentityCreationCredential,
-    IdentityType, IdentityTypeBootstrap, OutputTokenFormat, ProxyArgs, build_proxy_args,
-    create_metadata_for_bootstrap_identity_creation, create_metadata_for_identity_creation,
-    create_metadata_for_token_retrieve, extract_api_key_from_bootstrap,
-    extract_identity_creation_credential, select_output_platform, select_output_platform_bootstrap,
+    AuthenticationArgs, Commands, DEFAULT_AUTHENTICATOR_TIMEOUT, IdentityType, IdentityVariant,
+    OutputTokenFormat, ProxyArgs, build_proxy_args, create_metadata_for_token_retrieve,
 };
-use nr_auth::system_identity::iam_client::http::{HttpIAMClient, IAMAuthCredential};
+use nr_auth::system_identity::iam_client::http::HttpIAMClient;
 use std::error::Error;
 
 #[derive(Parser, Debug)]
@@ -32,10 +29,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     match cli_command.command {
         Commands::CreateIdentity { identity_type } => {
-            handle_create_identity_command(http_client, identity_type)
+            handle_create_identity_common(http_client, IdentityType::Standard(identity_type))
         }
         Commands::CreateBootstrapIdentity { identity_type } => {
-            handle_create_bootstrap_identity_command(http_client, identity_type)
+            handle_create_identity_common(http_client, IdentityType::Bootstrap(identity_type))
         }
         Commands::Authenticate {
             auth_args,
@@ -44,56 +41,25 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-fn handle_create_identity_command(
+fn handle_create_identity_common(
     http_client: HttpClient,
     identity_type: IdentityType,
 ) -> Result<(), Box<dyn Error>> {
-    let credential = extract_identity_creation_credential(&identity_type)?;
+    let metadata = identity_type.get_creation_metadata();
+    let iam_client = HttpIAMClient::new(http_client, metadata);
+    let create_command = CreateCommand::new(&iam_client);
 
-    let iam_auth_credential = match credential {
-        IdentityCreationCredential::BearerToken(token) => IAMAuthCredential::BearerToken(token),
-        IdentityCreationCredential::ApiKey(api_key) => IAMAuthCredential::ApiKey(api_key),
-    };
-
-    let meta = create_metadata_for_identity_creation(&identity_type);
-    let iam_client = &HttpIAMClient::new(http_client, meta);
-    let create_command = CreateCommand::new(iam_client);
-
-    let system_identity = match identity_type {
-        IdentityType::Secret(_) => {
-            create_command.create_l1_with_credential(&iam_auth_credential)?
-        }
-        IdentityType::Key(key_args) => {
-            let output_platform = select_output_platform(key_args);
-            create_command.create_l2_with_credential(&output_platform, &iam_auth_credential)?
+    let credential = identity_type.get_iam_credential();
+    let system_identity = match identity_type.get_variant() {
+        IdentityVariant::Secret => create_command.create_l1_with_credential(&credential)?,
+        IdentityVariant::Key(output_platform) => {
+            create_command.create_l2_with_credential(&output_platform, &credential)?
         }
     };
 
-    println!("{}", serde_json::to_string(&system_identity)?);
-    Ok(())
-}
-
-fn handle_create_bootstrap_identity_command(
-    http_client: HttpClient,
-    identity_type: IdentityTypeBootstrap,
-) -> Result<(), Box<dyn Error>> {
-    let metadata = create_metadata_for_bootstrap_identity_creation(&identity_type);
-    let auth_credential = IAMAuthCredential::ApiKey(extract_api_key_from_bootstrap(&identity_type));
-
-    let iam_client = &HttpIAMClient::new(http_client, metadata);
-    let create_command = CreateCommand::new(iam_client);
-
-    let system_identity = match identity_type {
-        IdentityTypeBootstrap::Secret(_) => {
-            create_command.create_l1_with_credential(&auth_credential)?
-        }
-        IdentityTypeBootstrap::Key(key_args) => {
-            let output_platform = select_output_platform_bootstrap(key_args);
-            create_command.create_l2_with_credential(&output_platform, &auth_credential)?
-        }
-    };
-
-    iam_client.add_identity_to_nr_control_group_by_id(&system_identity.id, &auth_credential)?;
+    if matches!(identity_type, IdentityType::Bootstrap(_)) {
+        iam_client.add_identity_to_nr_control_group_by_id(&system_identity.id, &credential)?;
+    }
 
     println!("{}", serde_json::to_string(&system_identity)?);
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -5,8 +5,9 @@ use nr_auth::commands::retrieve_token::RetrieveTokenCommand;
 use nr_auth::http::client::HttpClient;
 use nr_auth::http::config::HttpConfig;
 use nr_auth::parameters::{
-    AuthenticationArgs, Commands, DEFAULT_AUTHENTICATOR_TIMEOUT, IdentityType, IdentityVariant,
-    OutputTokenFormat, ProxyArgs, build_proxy_args, create_metadata_for_token_retrieve,
+    AuthenticationArgs, BasicAuthArgs, Commands, DEFAULT_AUTHENTICATOR_TIMEOUT, IdentityType,
+    IdentityVariant, OutputTokenFormat, ProxyArgs, build_proxy_args,
+    create_metadata_for_token_retrieve,
 };
 use nr_auth::system_identity::iam_client::http::HttpIAMClient;
 use std::error::Error;
@@ -28,12 +29,22 @@ fn main() -> Result<(), Box<dyn Error>> {
     let http_client = init_http_client(cli_command.proxy_args)?;
 
     match cli_command.command {
-        Commands::CreateIdentity { identity_type } => {
-            handle_create_identity_common(http_client, IdentityType::Standard(identity_type))
-        }
-        Commands::CreateBootstrapIdentity { identity_type } => {
-            handle_create_identity_common(http_client, IdentityType::Bootstrap(identity_type))
-        }
+        Commands::CreateIdentity {
+            basic_auth_args,
+            identity_type,
+        } => handle_create_identity_common(
+            http_client,
+            basic_auth_args,
+            IdentityType::Standard(identity_type),
+        ),
+        Commands::CreateBootstrapIdentity {
+            basic_auth_args,
+            identity_type,
+        } => handle_create_identity_common(
+            http_client,
+            basic_auth_args,
+            IdentityType::Bootstrap(identity_type),
+        ),
         Commands::Authenticate {
             auth_args,
             output_token_format,
@@ -43,9 +54,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn handle_create_identity_common(
     http_client: HttpClient,
+    basic_auth_args: BasicAuthArgs,
     identity_type: IdentityType,
 ) -> Result<(), Box<dyn Error>> {
-    let metadata = identity_type.get_creation_metadata();
+    let metadata = basic_auth_args.to_system_identity_creation_metadata();
     let iam_client = HttpIAMClient::new(http_client, metadata);
     let create_command = CreateCommand::new(&iam_client);
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -8,11 +8,8 @@ use crate::system_identity::input_data::{
     SystemIdentityCreationMetadata, SystemTokenCreationMetadata,
 };
 use clap::{Args, Error, Subcommand, ValueEnum};
-use std::clone::Clone;
-use std::convert::{From, Into};
 use std::fs;
 use std::path::PathBuf;
-use std::result::Result;
 use std::time::Duration;
 
 pub const DEFAULT_AUTHENTICATOR_TIMEOUT: Duration = Duration::from_secs(5);
@@ -31,6 +28,10 @@ pub enum Commands {
     ///    - Does not expire.
     ///
     CreateIdentity {
+        /// Basic information need for auth name, client_id, etc.
+        #[command(flatten)]
+        basic_auth_args: BasicAuthArgs,
+
         #[command(subcommand)]
         identity_type: StandardIdentityType,
     },
@@ -40,6 +41,10 @@ pub enum Commands {
     /// Bootstrap identities can create other identities. Only API key authentication is supported.
     ///
     CreateBootstrapIdentity {
+        /// Basic information need for auth name, client_id, etc.
+        #[command(flatten)]
+        basic_auth_args: BasicAuthArgs,
+
         #[command(subcommand)]
         identity_type: IdentityTypeBootstrap,
     },
@@ -154,6 +159,16 @@ pub struct BasicAuthArgs {
     environment: Environments,
 }
 
+impl BasicAuthArgs {
+    pub fn to_system_identity_creation_metadata(&self) -> SystemIdentityCreationMetadata {
+        SystemIdentityCreationMetadata {
+            organization_id: self.organization_id.clone(),
+            name: self.name.clone(),
+            environment: self.environment.into(),
+        }
+    }
+}
+
 #[derive(ValueEnum, Copy, Clone, Debug, PartialEq)]
 pub enum Environments {
     #[value(name = "US", alias = "Us", alias = "us")]
@@ -178,28 +193,15 @@ impl IdentityType {
         }
     }
 
-    pub fn get_creation_metadata(&self) -> SystemIdentityCreationMetadata {
-        let basic_auth_args = match self {
-            Self::Standard(identity_type) => identity_type.get_basic_auth_args(),
-            Self::Bootstrap(identity_type) => identity_type.get_basic_auth_args(),
-        };
-
-        SystemIdentityCreationMetadata {
-            organization_id: basic_auth_args.organization_id,
-            name: basic_auth_args.name.clone(),
-            environment: basic_auth_args.environment.into(),
-        }
-    }
-
     pub fn get_variant(&self) -> IdentityVariant {
         match self {
-            Self::Standard(StandardIdentityType::Secret(_)) => IdentityVariant::Secret,
-            Self::Standard(StandardIdentityType::Key(key_args)) => {
-                IdentityVariant::Key(select_output_platform(&key_args.output_options))
+            Self::Standard(StandardIdentityType::Secret { .. }) => IdentityVariant::Secret,
+            Self::Standard(StandardIdentityType::Key { output_options, .. }) => {
+                IdentityVariant::Key(select_output_platform(output_options))
             }
-            Self::Bootstrap(IdentityTypeBootstrap::Secret(_)) => IdentityVariant::Secret,
-            Self::Bootstrap(IdentityTypeBootstrap::Key(key_args)) => {
-                IdentityVariant::Key(select_output_platform(&key_args.output_options))
+            Self::Bootstrap(IdentityTypeBootstrap::Secret { .. }) => IdentityVariant::Secret,
+            Self::Bootstrap(IdentityTypeBootstrap::Key { output_options, .. }) => {
+                IdentityVariant::Key(select_output_platform(output_options))
             }
         }
     }
@@ -240,7 +242,11 @@ pub enum StandardIdentityType {
     /// client_secret: "AfYFAUjf9",
     /// credential_expiration: "2025-06-04T19:25:00Z"
     /// }}
-    Secret(SecretArgsStandard),
+    Secret {
+        /// Authentication method for identity creation
+        #[command(flatten)]
+        auth_credential: AuthCredentialArgs,
+    },
     #[command(verbatim_doc_comment)]
     /// Creates an identity whose type is 'private key'
     /// This type of identity does not expire.
@@ -253,57 +259,34 @@ pub enum StandardIdentityType {
     /// client_id: 8150a0ee,
     /// organization_id: b961cf81,
     /// identity_type: L2(pub_key: LS0tLS1))
-    Key(KeyArgsStandard),
-}
+    Key {
+        /// Authentication method for identity creation
+        #[command(flatten)]
+        auth_credential: AuthCredentialArgs,
 
-#[derive(Args, Debug, Clone)]
-pub struct SecretArgsStandard {
-    /// Basic information need for auth name, client_id, etc.
-    #[command(flatten)]
-    basic_auth_args: BasicAuthArgs,
-
-    /// Authentication method for identity creation
-    #[command(flatten)]
-    auth_credential: AuthCredentialArgs,
-}
-
-#[derive(Args, Debug, Clone)]
-pub struct KeyArgsStandard {
-    /// Basic information need for auth name, client_id, etc.
-    #[command(flatten)]
-    basic_auth_args: BasicAuthArgs,
-
-    /// Authentication method for identity creation
-    #[command(flatten)]
-    auth_credential: AuthCredentialArgs,
-
-    /// Options for configuring the output destination (required for Key identity)
-    #[command(flatten)]
-    output_options: OutputDestinationArgs,
+        /// Options for configuring the output destination (required for Key identity)
+        #[command(flatten)]
+        output_options: OutputDestinationArgs,
+    },
 }
 
 impl StandardIdentityType {
     fn get_iam_credential(&self) -> IAMAuthCredential {
         let auth_credential = match self {
-            StandardIdentityType::Secret(secret_args) => &secret_args.auth_credential,
-            StandardIdentityType::Key(key_args) => &key_args.auth_credential,
+            StandardIdentityType::Secret { auth_credential } => auth_credential,
+            StandardIdentityType::Key {
+                auth_credential, ..
+            } => auth_credential,
         };
 
         if let Some(token) = &auth_credential.bearer_access_token {
-            return IAMAuthCredential::BearerToken(token.clone());
+            IAMAuthCredential::BearerToken(token.clone())
         } else if let Some(api_key) = &auth_credential.api_key {
-            return IAMAuthCredential::ApiKey(api_key.clone());
+            IAMAuthCredential::ApiKey(api_key.clone())
         } else {
             // This should never happen. We told clap that one of the arguments in
             // AuthCredentialArgs must be provided.
             panic!("Either --bearer-access-token or --api-key must be provided");
-        }
-    }
-
-    fn get_basic_auth_args(&self) -> BasicAuthArgs {
-        match self {
-            StandardIdentityType::Secret(secret_args) => secret_args.basic_auth_args.clone(),
-            StandardIdentityType::Key(key_args) => key_args.basic_auth_args.clone(),
         }
     }
 }
@@ -312,46 +295,27 @@ impl StandardIdentityType {
 pub enum IdentityTypeBootstrap {
     #[command(verbatim_doc_comment)]
     /// Creates secret (L1, expires) bootstrap identity.
-    Secret(SecretArgsBootstrap),
+    Secret {
+        #[arg(long)]
+        api_key: String,
+    },
     #[command(verbatim_doc_comment)]
     /// Creates key (L2, does not expire) bootstrap identity.
-    Key(KeyArgsBootstrap),
-}
+    Key {
+        #[arg(long)]
+        api_key: String,
 
-#[derive(Args, Debug, Clone)]
-pub struct SecretArgsBootstrap {
-    #[command(flatten)]
-    basic_auth_args: BasicAuthArgs,
-
-    #[arg(long)]
-    api_key: String,
-}
-
-#[derive(Args, Debug, Clone)]
-pub struct KeyArgsBootstrap {
-    #[command(flatten)]
-    basic_auth_args: BasicAuthArgs,
-
-    #[arg(long)]
-    api_key: String,
-
-    #[command(flatten)]
-    output_options: OutputDestinationArgs,
+        #[command(flatten)]
+        output_options: OutputDestinationArgs,
+    },
 }
 
 impl IdentityTypeBootstrap {
     fn get_iam_credential(&self) -> IAMAuthCredential {
         IAMAuthCredential::ApiKey(match self {
-            IdentityTypeBootstrap::Secret(secret_args) => secret_args.api_key.clone(),
-            IdentityTypeBootstrap::Key(key_args) => key_args.api_key.clone(),
+            IdentityTypeBootstrap::Secret { api_key } => api_key.clone(),
+            IdentityTypeBootstrap::Key { api_key, .. } => api_key.clone(),
         })
-    }
-
-    fn get_basic_auth_args(&self) -> BasicAuthArgs {
-        match self {
-            IdentityTypeBootstrap::Secret(secret_args) => secret_args.basic_auth_args.clone(),
-            IdentityTypeBootstrap::Key(key_args) => key_args.basic_auth_args.clone(),
-        }
     }
 }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,12 +1,12 @@
 use crate::http::config::ProxyConfig;
 use crate::key::PrivateKeyPem;
+use crate::system_identity::iam_client::http::IAMAuthCredential;
 use crate::system_identity::input_data::auth_method::{AuthMethod, ClientSecret};
 use crate::system_identity::input_data::environment::NewRelicEnvironment;
 use crate::system_identity::input_data::output_platform::OutputPlatform;
 use crate::system_identity::input_data::{
     SystemIdentityCreationMetadata, SystemTokenCreationMetadata,
 };
-use clap::error::ErrorKind::MissingRequiredArgument;
 use clap::{Args, Error, Subcommand, ValueEnum};
 use std::clone::Clone;
 use std::convert::{From, Into};
@@ -14,14 +14,6 @@ use std::fs;
 use std::path::PathBuf;
 use std::result::Result;
 use std::time::Duration;
-
-#[derive(Debug, Clone)]
-pub enum IdentityCreationCredential {
-    /// Bearer token from OAuth authentication flow
-    BearerToken(String),
-    /// New Relic User API Key
-    ApiKey(String),
-}
 
 pub const DEFAULT_AUTHENTICATOR_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Subcommand, Debug)]
@@ -40,7 +32,7 @@ pub enum Commands {
     ///
     CreateIdentity {
         #[command(subcommand)]
-        identity_type: IdentityType,
+        identity_type: StandardIdentityType,
     },
     #[command(verbatim_doc_comment)]
     /// Creates a bootstrap system identity with NR Control Group membership.
@@ -172,8 +164,67 @@ pub enum Environments {
     STAGING,
 }
 
-#[derive(Subcommand, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub enum IdentityType {
+    Standard(StandardIdentityType),
+    Bootstrap(IdentityTypeBootstrap),
+}
+
+impl IdentityType {
+    pub fn get_iam_credential(&self) -> IAMAuthCredential {
+        match self {
+            Self::Standard(identity_type) => identity_type.get_iam_credential(),
+            Self::Bootstrap(identity_type) => identity_type.get_iam_credential(),
+        }
+    }
+
+    pub fn get_creation_metadata(&self) -> SystemIdentityCreationMetadata {
+        let basic_auth_args = match self {
+            Self::Standard(identity_type) => identity_type.get_basic_auth_args(),
+            Self::Bootstrap(identity_type) => identity_type.get_basic_auth_args(),
+        };
+
+        SystemIdentityCreationMetadata {
+            organization_id: basic_auth_args.organization_id,
+            name: basic_auth_args.name.clone(),
+            environment: basic_auth_args.environment.into(),
+        }
+    }
+
+    pub fn get_variant(&self) -> IdentityVariant {
+        match self {
+            Self::Standard(StandardIdentityType::Secret(_)) => IdentityVariant::Secret,
+            Self::Standard(StandardIdentityType::Key(key_args)) => {
+                IdentityVariant::Key(select_output_platform(&key_args.output_options))
+            }
+            Self::Bootstrap(IdentityTypeBootstrap::Secret(_)) => IdentityVariant::Secret,
+            Self::Bootstrap(IdentityTypeBootstrap::Key(key_args)) => {
+                IdentityVariant::Key(select_output_platform(&key_args.output_options))
+            }
+        }
+    }
+}
+
+fn select_output_platform(output_options: &OutputDestinationArgs) -> OutputPlatform {
+    let output_platform = &output_options.output_platform;
+    let output_filepath = output_options.output_local_filepath.clone();
+
+    match output_platform {
+        OutputPlatformChoice::LocalFile => {
+            OutputPlatform::LocalPrivateKeyPath(output_filepath.unwrap_or_default())
+        }
+    }
+}
+
+/// Helper enum to distinguish between Secret and Key identity variants
+#[derive(Debug, Clone)]
+pub enum IdentityVariant {
+    Secret,
+    Key(OutputPlatform),
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum StandardIdentityType {
     #[command(verbatim_doc_comment)]
     /// Creates an identity whose type is 'secret'
     /// This type of identity expires
@@ -189,7 +240,7 @@ pub enum IdentityType {
     /// client_secret: "AfYFAUjf9",
     /// credential_expiration: "2025-06-04T19:25:00Z"
     /// }}
-    Secret(SecretArgs),
+    Secret(SecretArgsStandard),
     #[command(verbatim_doc_comment)]
     /// Creates an identity whose type is 'private key'
     /// This type of identity does not expire.
@@ -202,21 +253,22 @@ pub enum IdentityType {
     /// client_id: 8150a0ee,
     /// organization_id: b961cf81,
     /// identity_type: L2(pub_key: LS0tLS1))
-    Key(KeyArgs),
-}
-
-#[derive(Subcommand, Debug, Clone)]
-pub enum IdentityTypeBootstrap {
-    #[command(verbatim_doc_comment)]
-    /// Creates secret (L1, expires) bootstrap identity.
-    Secret(SecretArgsBootstrap),
-    #[command(verbatim_doc_comment)]
-    /// Creates key (L2, does not expire) bootstrap identity.
-    Key(KeyArgsBootstrap),
+    Key(KeyArgsStandard),
 }
 
 #[derive(Args, Debug, Clone)]
-pub struct KeyArgs {
+pub struct SecretArgsStandard {
+    /// Basic information need for auth name, client_id, etc.
+    #[command(flatten)]
+    basic_auth_args: BasicAuthArgs,
+
+    /// Authentication method for identity creation
+    #[command(flatten)]
+    auth_credential: AuthCredentialArgs,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct KeyArgsStandard {
     /// Basic information need for auth name, client_id, etc.
     #[command(flatten)]
     basic_auth_args: BasicAuthArgs,
@@ -230,15 +282,49 @@ pub struct KeyArgs {
     output_options: OutputDestinationArgs,
 }
 
+impl StandardIdentityType {
+    fn get_iam_credential(&self) -> IAMAuthCredential {
+        let auth_credential = match self {
+            StandardIdentityType::Secret(secret_args) => &secret_args.auth_credential,
+            StandardIdentityType::Key(key_args) => &key_args.auth_credential,
+        };
+
+        if let Some(token) = &auth_credential.bearer_access_token {
+            return IAMAuthCredential::BearerToken(token.clone());
+        } else if let Some(api_key) = &auth_credential.api_key {
+            return IAMAuthCredential::ApiKey(api_key.clone());
+        } else {
+            // This should never happen. We told clap that one of the arguments in
+            // AuthCredentialArgs must be provided.
+            panic!("Either --bearer-access-token or --api-key must be provided");
+        }
+    }
+
+    fn get_basic_auth_args(&self) -> BasicAuthArgs {
+        match self {
+            StandardIdentityType::Secret(secret_args) => secret_args.basic_auth_args.clone(),
+            StandardIdentityType::Key(key_args) => key_args.basic_auth_args.clone(),
+        }
+    }
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum IdentityTypeBootstrap {
+    #[command(verbatim_doc_comment)]
+    /// Creates secret (L1, expires) bootstrap identity.
+    Secret(SecretArgsBootstrap),
+    #[command(verbatim_doc_comment)]
+    /// Creates key (L2, does not expire) bootstrap identity.
+    Key(KeyArgsBootstrap),
+}
+
 #[derive(Args, Debug, Clone)]
-pub struct SecretArgs {
-    /// Basic information need for auth name, client_id, etc.
+pub struct SecretArgsBootstrap {
     #[command(flatten)]
     basic_auth_args: BasicAuthArgs,
 
-    /// Authentication method for identity creation
-    #[command(flatten)]
-    auth_credential: AuthCredentialArgs,
+    #[arg(long)]
+    api_key: String,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -253,13 +339,20 @@ pub struct KeyArgsBootstrap {
     output_options: OutputDestinationArgs,
 }
 
-#[derive(Args, Debug, Clone)]
-pub struct SecretArgsBootstrap {
-    #[command(flatten)]
-    basic_auth_args: BasicAuthArgs,
+impl IdentityTypeBootstrap {
+    fn get_iam_credential(&self) -> IAMAuthCredential {
+        IAMAuthCredential::ApiKey(match self {
+            IdentityTypeBootstrap::Secret(secret_args) => secret_args.api_key.clone(),
+            IdentityTypeBootstrap::Key(key_args) => key_args.api_key.clone(),
+        })
+    }
 
-    #[arg(long)]
-    api_key: String,
+    fn get_basic_auth_args(&self) -> BasicAuthArgs {
+        match self {
+            IdentityTypeBootstrap::Secret(secret_args) => secret_args.basic_auth_args.clone(),
+            IdentityTypeBootstrap::Key(key_args) => key_args.basic_auth_args.clone(),
+        }
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -306,66 +399,7 @@ pub fn create_metadata_for_token_retrieve(
     })
 }
 
-pub fn create_metadata_for_identity_creation(
-    identity_type: &IdentityType,
-) -> SystemIdentityCreationMetadata {
-    let basic_auth_args = match identity_type {
-        IdentityType::Secret(secret_args) => secret_args.basic_auth_args.clone(),
-        IdentityType::Key(key_args) => key_args.basic_auth_args.clone(),
-    };
-
-    SystemIdentityCreationMetadata {
-        organization_id: basic_auth_args.organization_id,
-        name: basic_auth_args.name.clone(),
-        environment: basic_auth_args.environment.into(),
-    }
-}
-
-impl From<Environments> for NewRelicEnvironment {
-    fn from(value: Environments) -> Self {
-        match value {
-            Environments::US => NewRelicEnvironment::US,
-            Environments::EU => NewRelicEnvironment::EU,
-            Environments::STAGING => NewRelicEnvironment::Staging,
-        }
-    }
-}
-
-/// Extracts the authentication credential from the identity creation arguments
-pub fn extract_identity_creation_credential(
-    identity_type: &IdentityType,
-) -> Result<IdentityCreationCredential, Box<dyn std::error::Error>> {
-    let auth_credential = match identity_type {
-        IdentityType::Secret(secret_args) => &secret_args.auth_credential,
-        IdentityType::Key(key_args) => &key_args.auth_credential,
-    };
-
-    if let Some(bearer_token) = &auth_credential.bearer_access_token {
-        Ok(IdentityCreationCredential::BearerToken(
-            bearer_token.clone(),
-        ))
-    } else if let Some(api_key) = &auth_credential.api_key {
-        Ok(IdentityCreationCredential::ApiKey(api_key.clone()))
-    } else {
-        Err(Error::raw(
-            MissingRequiredArgument,
-            "Either --bearer-access-token or --api-key must be provided",
-        ))?
-    }
-}
-
-pub fn select_output_platform(key_args: KeyArgs) -> OutputPlatform {
-    let output_platform = &key_args.output_options.output_platform;
-    let output_filepath = key_args.output_options.output_local_filepath.clone();
-
-    match output_platform {
-        OutputPlatformChoice::LocalFile => {
-            OutputPlatform::LocalPrivateKeyPath(output_filepath.unwrap_or_default())
-        }
-    }
-}
-
-pub fn select_auth_method(
+fn select_auth_method(
     input_client_secret: Option<String>,
     input_private_key_path: Option<PathBuf>,
 ) -> Result<AuthMethod, Error> {
@@ -381,35 +415,12 @@ pub fn select_auth_method(
     }
 }
 
-pub fn create_metadata_for_bootstrap_identity_creation(
-    identity_type: &IdentityTypeBootstrap,
-) -> SystemIdentityCreationMetadata {
-    let basic_auth_args = match identity_type {
-        IdentityTypeBootstrap::Secret(secret_args) => secret_args.basic_auth_args.clone(),
-        IdentityTypeBootstrap::Key(key_args) => key_args.basic_auth_args.clone(),
-    };
-
-    SystemIdentityCreationMetadata {
-        organization_id: basic_auth_args.organization_id,
-        name: basic_auth_args.name.clone(),
-        environment: basic_auth_args.environment.into(),
-    }
-}
-
-pub fn extract_api_key_from_bootstrap(identity_type: &IdentityTypeBootstrap) -> String {
-    match identity_type {
-        IdentityTypeBootstrap::Secret(secret_args) => secret_args.api_key.clone(),
-        IdentityTypeBootstrap::Key(key_args) => key_args.api_key.clone(),
-    }
-}
-
-pub fn select_output_platform_bootstrap(key_args: KeyArgsBootstrap) -> OutputPlatform {
-    let output_platform = &key_args.output_options.output_platform;
-    let output_filepath = key_args.output_options.output_local_filepath.clone();
-
-    match output_platform {
-        OutputPlatformChoice::LocalFile => {
-            OutputPlatform::LocalPrivateKeyPath(output_filepath.unwrap_or_default())
+impl From<Environments> for NewRelicEnvironment {
+    fn from(value: Environments) -> Self {
+        match value {
+            Environments::US => NewRelicEnvironment::US,
+            Environments::EU => NewRelicEnvironment::EU,
+            Environments::STAGING => NewRelicEnvironment::Staging,
         }
     }
 }


### PR DESCRIPTION
Modify cli inputs to simplify code.

**Context**

We were wondering with Paolo if inputs could be simplified with clap and how. I was curious. I investigated and came up with what you can see on the PR. Basically, I've moved out the basic auth args from each subcommand into the top level commands. That way, there's less duplication. Subcommands only have specific args. I also "inlined" the subcommand structs. Now that they only have specific args, I think there's no need for extra structs.

This simplifies the code a great deal, but introduces a breaking change. This PR is on top of another refactor. https://github.com/newrelic/newrelic-auth-rs/pull/197. Maybe this "improvement" could be done separately. 
Up to you @paologallinaharbur. I'm out next week, so take them and work on them or close them as you see fit.

I don't know if it's worth it working on any of these PRs right now. It might be a good time, now that we have the context fresh (if other people also believe that the improvements are worth). Alternatively, we could leave those PRs here and work on them if we ever need to implement something else in this repo.