### PR TITLE
fix: log oauth client errors

### DIFF
--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -54,9 +54,7 @@ impl HttpClient {
 
         debug!("Request body: {:?}", req);
 
-        let res = req
-            .send()
-            .map_err(from_reqwest_error)?;
+        let res = req.send().map_err(from_reqwest_error)?;
 
         try_build_response(res)
     }
@@ -162,20 +160,15 @@ impl OauthHttpClient for HttpClient {
 impl From<HttpResponseError> for OauthHttpClientError {
     fn from(err: HttpResponseError) -> Self {
         match err {
-            HttpResponseError::ConnectError(_) 
-            |
-            HttpResponseError::TimeoutError(_) 
-            |
-            HttpResponseError::DnsError(_) 
-            |
-            HttpResponseError::GenericTransportError(_) => {
+            HttpResponseError::ConnectError(_)
+            | HttpResponseError::TimeoutError(_)
+            | HttpResponseError::DnsError(_)
+            | HttpResponseError::GenericTransportError(_) => {
                 OauthHttpClientError::TransportError(err.to_string())
             }
             HttpResponseError::BuildingRequest(msg)
             | HttpResponseError::BuildingResponse(msg)
-            | HttpResponseError::ReadingResponse(msg) => {
-                OauthHttpClientError::InvalidResponse(msg)
-            }
+            | HttpResponseError::ReadingResponse(msg) => OauthHttpClientError::InvalidResponse(msg),
         }
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -171,7 +171,6 @@ impl From<HttpResponseError> for OauthHttpClientError {
             HttpResponseError::GenericTransportError(_) => {
                 OauthHttpClientError::TransportError(err.to_string())
             }
-            HttpResponseError::TransportError(msg) => OauthHttpClientError::TransportError(msg),
             HttpResponseError::BuildingRequest(msg)
             | HttpResponseError::BuildingResponse(msg)
             | HttpResponseError::ReadingResponse(msg) => {
@@ -187,8 +186,6 @@ enum HttpResponseError {
     ReadingResponse(String),
     #[error("could not build response: {0}")]
     BuildingResponse(String),
-    #[error("http transport error: `{0}`")]
-    TransportError(String),
     #[error("could not build request: {0}")]
     BuildingRequest(String),
     #[error(

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -11,6 +11,8 @@ use std::{
 };
 use tracing::{debug, warn};
 
+type ReqwestError = reqwest::Error;
+
 const CERT_EXTENSION: &str = "pem";
 #[derive(Debug, Clone)]
 pub struct HttpClient {
@@ -54,7 +56,7 @@ impl HttpClient {
 
         let res = req
             .send()
-            .map_err(|err| HttpResponseError::TransportError(err.to_string()))?;
+            .map_err(from_reqwest_error)?;
 
         try_build_response(res)
     }
@@ -160,8 +162,19 @@ impl OauthHttpClient for HttpClient {
 impl From<HttpResponseError> for OauthHttpClientError {
     fn from(err: HttpResponseError) -> Self {
         match err {
+            HttpResponseError::ConnectError(_) 
+            |
+            HttpResponseError::TimeoutError(_) 
+            |
+            HttpResponseError::DnsError(_) 
+            |
+            HttpResponseError::GenericTransportError(_) => {
+                OauthHttpClientError::TransportError(err.to_string())
+            }
             HttpResponseError::TransportError(msg) => OauthHttpClientError::TransportError(msg),
-            HttpResponseError::BuildingResponse(msg) | HttpResponseError::ReadingResponse(msg) => {
+            HttpResponseError::BuildingRequest(msg)
+            | HttpResponseError::BuildingResponse(msg)
+            | HttpResponseError::ReadingResponse(msg) => {
                 OauthHttpClientError::InvalidResponse(msg)
             }
         }
@@ -176,6 +189,36 @@ enum HttpResponseError {
     BuildingResponse(String),
     #[error("http transport error: `{0}`")]
     TransportError(String),
+    #[error("could not build request: {0}")]
+    BuildingRequest(String),
+    #[error(
+        "connection error: could not connect to the host. this is often caused by a firewall, proxy, or network routing issue. original error: {0}"
+    )]
+    ConnectError(#[source] ReqwestError),
+    #[error("timeout error: the request timed out. original error: {0}")]
+    TimeoutError(#[source] ReqwestError),
+    #[error(
+        "dns resolution error: could not resolve the host. please check your dns configuration. original error: {0}"
+    )]
+    DnsError(#[source] ReqwestError),
+    #[error("generic transport error: {0}")]
+    GenericTransportError(#[source] ReqwestError),
+}
+
+fn from_reqwest_error(e: ReqwestError) -> HttpResponseError {
+    if e.is_connect() {
+        HttpResponseError::ConnectError(e)
+    } else if e.is_timeout() {
+        HttpResponseError::TimeoutError(e)
+    } else if e.is_builder() || e.is_request() {
+        if e.to_string().to_lowercase().contains("dns") {
+            HttpResponseError::DnsError(e)
+        } else {
+            HttpResponseError::BuildingRequest(e.to_string())
+        }
+    } else {
+        HttpResponseError::GenericTransportError(e)
+    }
 }
 
 #[cfg(test)]

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -181,7 +181,7 @@ impl From<HttpResponseError> for OauthHttpClientError {
                     status_code,
                     String::from_utf8_lossy(&body)
                 );
-                OauthHttpClientError::HTTPBodyError(msg)
+                OauthHttpClientError::InvalidResponse(msg)
             }
             HttpResponseError::BuildingRequest(msg)
             | HttpResponseError::BuildingResponse(msg)
@@ -198,7 +198,7 @@ enum HttpResponseError {
     BuildingResponse(String),
     #[error("could not build request: {0}")]
     BuildingRequest(String),
-    // Represents a response that was received, but had a non-successful status code.
+    /// Represents a response that was received, but had a non-successful status code.
     #[error(
         "unsuccessful response: {status_code} - body: {}",
         String::from_utf8_lossy(body)
@@ -247,6 +247,7 @@ mod tests {
     use httpmock::MockServer;
     use std::fs::File;
     use std::io::Write;
+    use std::time::Duration;
     use tempfile::tempdir;
 
     const INVALID_TESTING_CERT: &str =
@@ -376,5 +377,41 @@ mod tests {
         let ca_bundle_file = PathBuf::default();
         let certificates = certs_from_paths(&ca_bundle_file, ca_bundle_dir).unwrap();
         assert_eq!(certificates.len(), 1);
+    }
+
+    #[test]
+    fn test_error_conversions() {
+        let http_err = HttpResponseError::UnsuccessfulResponse {
+            status_code: StatusCode::UNAUTHORIZED,
+            body: b"invalid token".to_vec(),
+        };
+        let oauth_err: OauthHttpClientError = http_err.into();
+        assert_matches!(oauth_err, OauthHttpClientError::InvalidResponse(_));
+        assert!(oauth_err.to_string().contains("HTTP Error 401"));
+    }
+
+    #[test]
+    fn test_http_client_timeout() {
+        let mock_server = MockServer::start();
+        mock_server.mock(|when, then| {
+            when.path("/");
+            then.delay(Duration::from_millis(200)).status(200);
+        });
+
+        let http_config = HttpConfig::new(
+            Duration::from_millis(50),
+            Duration::from_millis(50),
+            Default::default(),
+        );
+        let http_client = HttpClient::new(http_config).unwrap();
+
+        let request = Request::builder()
+            .uri(mock_server.url("/").as_str())
+            .method("GET")
+            .body(Vec::new())
+            .unwrap();
+
+        let result = http_client.send(request);
+        assert_matches!(result, Err(HttpResponseError::TimeoutError(_)));
     }
 }

--- a/src/http/client.rs
+++ b/src/http/client.rs
@@ -1,7 +1,7 @@
 use crate::http::config::HttpConfig;
 use crate::http_client::{HttpClient as OauthHttpClient, HttpClientError as OauthHttpClientError};
 use http::Request;
-use http::{Response as HttpResponse, Response};
+use http::{Response as HttpResponse, Response, StatusCode};
 use reqwest::blocking::{Client, Response as BlockingResponse};
 use reqwest::tls::TlsInfo;
 use reqwest::{Certificate, Proxy};
@@ -56,7 +56,16 @@ impl HttpClient {
 
         let res = req.send().map_err(from_reqwest_error)?;
 
-        try_build_response(res)
+        if res.status().is_success() {
+            try_build_response(res)
+        } else {
+            let status_code = res.status();
+            let body = res
+                .bytes()
+                .map_err(|err| HttpResponseError::ReadingResponse(err.to_string()))?
+                .to_vec();
+            Err(HttpResponseError::UnsuccessfulResponse { status_code, body })
+        }
     }
 }
 
@@ -166,6 +175,14 @@ impl From<HttpResponseError> for OauthHttpClientError {
             | HttpResponseError::GenericTransportError(_) => {
                 OauthHttpClientError::TransportError(err.to_string())
             }
+            HttpResponseError::UnsuccessfulResponse { status_code, body } => {
+                let msg = format!(
+                    "HTTP Error {}: {}",
+                    status_code,
+                    String::from_utf8_lossy(&body)
+                );
+                OauthHttpClientError::HTTPBodyError(msg)
+            }
             HttpResponseError::BuildingRequest(msg)
             | HttpResponseError::BuildingResponse(msg)
             | HttpResponseError::ReadingResponse(msg) => OauthHttpClientError::InvalidResponse(msg),
@@ -181,6 +198,15 @@ enum HttpResponseError {
     BuildingResponse(String),
     #[error("could not build request: {0}")]
     BuildingRequest(String),
+    // Represents a response that was received, but had a non-successful status code.
+    #[error(
+        "unsuccessful response: {status_code} - body: {}",
+        String::from_utf8_lossy(body)
+    )]
+    UnsuccessfulResponse {
+        status_code: StatusCode,
+        body: Vec<u8>,
+    },
     #[error(
         "connection error: could not connect to the host. this is often caused by a firewall, proxy, or network routing issue. original error: {0}"
     )]

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -20,9 +20,6 @@ pub enum HttpClientError {
     /// Represents an unexpected response.
     #[error("invalid http response: `{0}`")]
     InvalidResponse(String),
-    /// Represents an http crate consume body error.
-    #[error("`{0}`")]
-    HTTPBodyError(String),
 }
 
 /// A synchronous trait that defines the internal methods for HTTP clients.

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -20,6 +20,9 @@ pub enum HttpClientError {
     /// Represents an unexpected response.
     #[error("invalid http response: `{0}`")]
     InvalidResponse(String),
+    /// Represents an http crate consume body error.
+    #[error("`{0}`")]
+    HTTPBodyError(String),
 }
 
 /// A synchronous trait that defines the internal methods for HTTP clients.


### PR DESCRIPTION
[NR-522024](https://new-relic.atlassian.net/browse/NR-552024)
This change should capture the specific error and log it, so the user can see it when troubleshooting the installation.

[NR-522024]: https://new-relic.atlassian.net/browse/NR-522024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ