### PR TITLE
fix: adapt notices template to tera v2

### DIFF
--- a/.github/workflows/on_prerelease.yml
+++ b/.github/workflows/on_prerelease.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: newrelic/rust-licenses-noticer@9d9bb4a5137f7c9d528b4ada1f505866947feccf # v1
+      - uses: newrelic/rust-licenses-noticer@aafd951d814aa31bbe4a5b463fd52ba208905562 # v1.0.4
         with:
           template-file: THIRD_PARTY_NOTICES.md.tmpl
 

--- a/THIRD_PARTY_NOTICES.md.tmpl
+++ b/THIRD_PARTY_NOTICES.md.tmpl
@@ -12,7 +12,7 @@ or by e-mailing [open-source@newrelic.com](mailto:open-source@newrelic.com).
 For any licenses that require the disclosure of source code, the source code
 can be found at <https://github.com/newrelic/newrelic-auth-rs>.
 {% for dep, licenseObj in dependencies %}
-{%- if dep is containing("nr-auth") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="nr-auth") %}{% continue %}{% endif %}
 ## {{ dep | split(pat=" ") | first }} <{{ dep | split(pat=" ") | last }}>
 
 Distributed under the following license(s):


### PR DESCRIPTION
## Summary

`rust-licenses-noticer` was upgraded to `tera` v2, which introduced a breaking change to test-argument syntax: test arguments must now be **named** rather than positional.

This updates `THIRD_PARTY_NOTICES.md.tmpl` so the `containing` test passes its pattern as the `pat` kwarg:

```diff
-{%- if dep is containing("nr-auth") %}{% continue %}{% endif %}
+{%- if dep is containing(pat="nr-auth") %}{% continue %}{% endif %}
```

Without this, notice generation fails with `Found string but expected identifier`.

## Related

Upstream fix: newrelic/rust-licenses-noticer#84